### PR TITLE
Default observerMode on Android to `false`, add option, pass `appUserID` on iOS

### DIFF
--- a/android/src/main/java/ee/forgr/plugin/capacitor_purchases/CapacitorPurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_purchases/CapacitorPurchasesPlugin.java
@@ -38,7 +38,7 @@ public class CapacitorPurchasesPlugin extends Plugin {
     public void setup(PluginCall call) {
         String apiKey = call.getString("apiKey");
         String appUserID = call.getString("appUserID");
-        String observerMode = call.getBoolean("observerMode") != null ? call.getBoolean("observerMode") : false;
+        Boolean observerMode = call.getBoolean("observerMode") != null ? call.getBoolean("observerMode") : false;
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         CommonKt.configure(this.bridge.getActivity(), apiKey, appUserID, observerMode, platformInfo);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(new UpdatedCustomerInfoListener() {

--- a/android/src/main/java/ee/forgr/plugin/capacitor_purchases/CapacitorPurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_purchases/CapacitorPurchasesPlugin.java
@@ -38,7 +38,7 @@ public class CapacitorPurchasesPlugin extends Plugin {
     public void setup(PluginCall call) {
         String apiKey = call.getString("apiKey");
         String appUserID = call.getString("appUserID");
-        Boolean observerMode = call.getBoolean("observerMode") != null ? call.getBoolean("observerMode") : false;
+        Boolean observerMode = call.getBoolean("observerMode", false);
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         CommonKt.configure(this.bridge.getActivity(), apiKey, appUserID, observerMode, platformInfo);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(new UpdatedCustomerInfoListener() {

--- a/android/src/main/java/ee/forgr/plugin/capacitor_purchases/CapacitorPurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_purchases/CapacitorPurchasesPlugin.java
@@ -38,8 +38,9 @@ public class CapacitorPurchasesPlugin extends Plugin {
     public void setup(PluginCall call) {
         String apiKey = call.getString("apiKey");
         String appUserID = call.getString("appUserID");
+        String observerMode = call.getBoolean("observerMode") != null ? call.getBoolean("observerMode") : false;
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
-        CommonKt.configure(this.bridge.getActivity(), apiKey, appUserID, true, platformInfo);
+        CommonKt.configure(this.bridge.getActivity(), apiKey, appUserID, observerMode, platformInfo);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(new UpdatedCustomerInfoListener() {
             @Override
             public void onReceived(@NonNull CustomerInfo purchaserInfo) {

--- a/ios/Plugin/CapacitorPurchasesPlugin.swift
+++ b/ios/Plugin/CapacitorPurchasesPlugin.swift
@@ -216,7 +216,13 @@ public class CapacitorPurchasesPlugin: CAPPlugin, PurchasesDelegate {
 
     @objc func setup(_ call: CAPPluginCall) {
         let apiKey = call.getString("apiKey") ?? ""
-        Purchases.configure(withAPIKey: apiKey)
+        let appUserID = call.getString("appUserID")
+        let observerMode = call.getBool("observerMode") ?? false
+        let configuration = Configuration.Builder(withAPIKey: apiKey)
+                                 .with(appUserID: appUserID)
+                                 .with(observerMode: observerMode)
+                                 .build()
+        Purchases.configure(with: configuration)
         Purchases.shared.delegate = self
         call.resolve()
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -530,9 +530,16 @@ export interface CapacitorPurchasesPlugin {
   /**
    * Sets up  with your API key and an app user id.
    * @param {string} apiKey RevenueCat API Key. Needs to be a string
+   * @param {string} [appUserID] The unique app user id for this user.
+   * This user id will allow users to share their purchases and subscriptions across devices.
+   * Leave empty if you want RevenueCat to generate this for you.
+   * @param {boolean} [observerMode = false] Set this to true if you have your own IAP implementation 
+   * and want to use only RevenueCat’s backend. Default is false.
    */
   setup(data: {
     apiKey: string,
+    appUserID?: string,
+    observerMode?: boolean,
   }): Promise<void>
 
   /**


### PR DESCRIPTION
First off, thanks so much for making this plugin!!! A lot of people are finding it really useful. 

I made this PR to address a couple of issues: 
As mentioned in https://github.com/Cap-go/capacitor-purchases/issues/10, on Android observerMode is currently getting set to `true`, which means that all purchases will be cancelled automatically unless the app finishes the transactions by itself. 

I added a parameter to set `observerMode` whenever needed, and also updated the default to `false` for Android, to match the existing value for iOS. 

I also noticed that on Android, the value for `appUserID` was being read and passed along, but it wasn't being read on iOS, so I added that too and updated the typescript definition. 

Lastly I updated to use the latest syntax for configuring the SDK on iOS. 

I haven't been able to test this out yet, so please be careful before merging. 

Let me know if there's anything you'd like me to update style-wise, and also let me know if you have any questions! 
